### PR TITLE
Add a workflow for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ Usage examples
     (ghub-get "/orgs/magit/repos"))
   ```
 
+* Making a request using basic authentication:
+
+  ```lisp
+  (let ((ghub-authenticate 'basic))
+    (ghub-post "/authorizations" nil
+               '((scopes . (public_repo))
+                 (note . "example"))))
+  ```
+
+
 Github Enterprise support
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ client for the Gitlab API.  See https://gitlab.com/tarsius/glab.
 If you don't like this, then you might instead like `gh.el`; a big
 client for the Github API.  See https://github.com/sigma/gh.el.
 
-If you would like to use `ghub.el`, but also want decicated
-functions for each API entpoint, then you can create those using
+If you would like to use `ghub.el`, but also want dedicated
+functions for each API endpoint, then you can create those using
 `apiwrap.el`.  See https://github.com/vermiculus/apiwrap.el.

--- a/ghub.el
+++ b/ghub.el
@@ -81,8 +81,8 @@
 ;; If you don't like this, then you might instead like `gh.el'; a big
 ;; client for the Github API.  See https://github.com/sigma/gh.el.
 
-;; If you would like to use `ghub.el', but also want decicated
-;; functions for each API entpoint, then you can create those using
+;; If you would like to use `ghub.el', but also want dedicated
+;; functions for each API endpoint, then you can create those using
 ;; `apiwrap.el'.  See https://github.com/vermiculus/apiwrap.el.
 
 ;;; Code:

--- a/ghub.el
+++ b/ghub.el
@@ -55,6 +55,13 @@
 ;;
 ;;   (let ((ghub-authenticate nil))
 ;;     (ghub-get "/orgs/magit/repos"))
+;;
+;; Making a request using basic authentication:
+;;
+;; (let ((ghub-authenticate 'basic))
+;;   (ghub-post "/authorizations" nil
+;;              '((scopes . (public_repo))
+;;                (note . "example"))))
 
 ;; Github Enterprise support
 ;; -------------------------
@@ -91,6 +98,7 @@
 (require 'json)
 (require 'subr-x)
 (require 'url)
+(require 'url-auth)
 
 (defvar url-http-end-of-headers)
 (defvar url-http-response-status)
@@ -132,8 +140,8 @@
          (d (and data   (json-encode-list data)))
          (url-request-extra-headers
           `(("Content-Type"  . "application/json")
-            ,@(when-let ((token (ghub--token)))
-                `(("Authorization" . ,(concat "token " token))))))
+            ,@(and ghub-authenticate
+                   `(("Authorization" . ,(ghub--get-auth))))))
          (url-request-method method)
          (url-request-data d))
     (with-current-buffer
@@ -182,17 +190,27 @@
                        (url-hexify-string val)))
              params "&"))
 
+(defun ghub--get-auth ()
+  (let* ((ghub-username (ghub--username))
+         (token (unless (eq ghub-authenticate 'basic)
+                  (ghub--token)))
+         url)
+    (if token
+        (concat "token " token)
+      (setq url (url-generic-parse-url ghub-base-url))
+      (setf (url-user url) ghub-username)
+      (url-basic-auth url t))))
+
 (defun ghub--token ()
-  (and ghub-authenticate
-       (or ghub-token
-           (let ((secret (plist-get (car (auth-source-search
-                                          :max 1
-                                          :user (ghub--username)
-                                          :host ghub-instance))
-                                    :secret)))
-             (if (functionp secret)
-                 (funcall secret)
-               secret)))))
+  (or ghub-token
+      (let ((secret (plist-get (car (auth-source-search
+                                     :max 1
+                                     :user (ghub--username)
+                                     :host ghub-instance))
+                               :secret)))
+        (if (functionp secret)
+            (funcall secret)
+          secret))))
 
 (defun ghub--username ()
   (or ghub-username


### PR DESCRIPTION
Example usage:

```lisp
(defun ghub-new-authentication (scopes note)
  "Authenticate with SCOPES using NOTE."
  (let ((ghub-authenticate 'basic))
    (cdr (assq 'token (ghub-post "/authorizations" nil
                                 `((scopes . ,scopes)
                                   (note . ,note)))))))
```

Addresses #4.