### PR TITLE
Fix auth configuration docs to match current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ emacs ~/.authinfo.gpg
 
 ```
 # -*- epa-file-encrypt-to: ("A.U.Thor@example.com") -*-
-machine api.github.com login <login> password <token>
+machine github.com login <login> password <token>
 ```
 
 Usage examples

--- a/ghub.el
+++ b/ghub.el
@@ -36,7 +36,7 @@
 ;;   $ git config github.user <username>
 ;;   $ emacs ~/.authinfo.gpg
 ;;   # -*- epa-file-encrypt-to: ("A.U.Thor@example.com") -*-
-;;   machine api.github.com login <login> password <token>
+;;   machine github.com login <login> password <token>
 
 ;; Usage examples
 ;; --------------


### PR DESCRIPTION
By the way, what's the difference between `ghub-instance` and `ghub-base-url`? How are they intended to be used? Couldn't the latter be figured from the former or is that something Enterprise customers can probably configure?