### PR TITLE
Read multibyte responses correctly

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -138,6 +138,7 @@
          (url-request-data d))
     (with-current-buffer
         (url-retrieve-synchronously (concat ghub-base-url resource p))
+      (set-buffer-multibyte t)
       (let (link body)
         (goto-char (point-min))
         (save-restriction


### PR DESCRIPTION
I'm not too sure why, but this fixes the response of

    "Nav Pills with open dropdown don't reflect the nav-pills active stateâ¦"

and returns instead

    "Nav Pills with open dropdown don't reflect the nav-pills active state…"

Before this change, we'd just `json-read` from the current buffer; after, `json-read-from-string` uses `with-temp-buffer` (which could be doing something funny with `set-buffer-multibyte`).

You can reproduce the issue and verify the fix with

    (ghub-get "/repos/twbs/bootstrap/issues/22485")