### PR TITLE
Support basic authentication and other authentication improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ dots replaced with underscores.
 Alternatives
 ------------
 
+If you like this, then you might never-the-less prefer `ghub+.el`;
+a thick GitHub API client built on `ghub.el'.
+See https://github.com/vermiculus/ghub-plus.
+
 If you like this, then you might also like `glab.el`; a minuscule
 client for the Gitlab API.  See https://gitlab.com/tarsius/glab.
 
 If you don't like this, then you might instead like `gh.el`; a big
 client for the Github API.  See https://github.com/sigma/gh.el.
-
-If you would like to use `ghub.el`, but also want dedicated
-functions for each API endpoint, then you can create those using
-`apiwrap.el`.  See https://github.com/vermiculus/apiwrap.el.

--- a/README.md
+++ b/README.md
@@ -3,14 +3,12 @@ Minuscule client for the Github API
 
 This library just provides the HTTP verbs.  Instead of wrapping
 every resource, I recommend https://developer.github.com/v3.
-Due to the lack of doc-strings, I also recommend having a quick
-look at the source, which is quite trivial.
 
 Initial configuration
 ---------------------
 
 ```shell
-$ git config github.user <username>
+$ git config --global github.user <username>
 $ emacs ~/.authinfo.gpg
 ```
 
@@ -18,6 +16,10 @@ $ emacs ~/.authinfo.gpg
 # -*- epa-file-encrypt-to: ("A.U.Thor@example.com") -*-
 machine api.github.com login <login> password <token>
 ```
+
+To acquire a token, go to https://github.com/settings/tokens.  Note
+that currently the same token is shared by all Emacs packages that
+use `ghub.el`.
 
 Usage examples
 --------------
@@ -57,14 +59,20 @@ Github Enterprise support
 * Initial configuration:
 
   ```shell
-  $ git config example_com.user employee
+  $ cd /path/to/repository
+  $ git config eg_example_com.user employee
   $ emacs ~/.authinfo.gpg
   ```
 
   ```
   # -*- epa-file-encrypt-to: ("employee@example.com") -*-
-  machine example.com/api/v3 login employee password <token>
+  machine gh.example.com/api/v3 login employee password <token>
   ```
+
+Note that unlike for Github.com, which uses `github.user`, the Git
+variable used to store the username for an Enterprise instance is
+named `HOST.user`, where HOST is the host part of the `URI`, with
+dots replaced with underscores.
 
 * Making a request:
 

--- a/README.md
+++ b/README.md
@@ -51,16 +51,18 @@ Github Enterprise support
   ```shell
   $ git config example_com.user employee
   $ emacs ~/.authinfo.gpg
+  ```
+
+  ```
   # -*- epa-file-encrypt-to: ("employee@example.com") -*-
-  machine example.com login employee password <token>
+  machine example.com/api/v3 login employee password <token>
   ```
 
 * Making a request:
 
   ```lisp
-  (let ((ghub-instance "example.com")
-        (ghub-base-url "https://example.com/api/v3"))
-    (ghub-get "/users/example/repos"))
+  (let ((ghub-base-url "https://example.com/api/v3"))
+    (ghub-get "/users/employee/repos"))
   ```
 
 Alternatives

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Usage examples
     (ghub-get "/orgs/magit/repos"))
   ```
 
+* Making a request using basic authentication:
+
+  ```lisp
+  (let ((ghub-authenticate 'basic))
+    (ghub-get "/orgs/magit/repos"))
+  ```
+
+
 Github Enterprise support
 -------------------------
 

--- a/ghub.el
+++ b/ghub.el
@@ -87,15 +87,15 @@
 ;; Alternatives
 ;; ------------
 
+;; If you like this, then you might never-the-less prefer `ghub+.el';
+;; a thick GitHub API client built on `ghub.el'.
+;; See https://github.com/vermiculus/ghub-plus.
+
 ;; If you like this, then you might also like `glab.el'; a minuscule
 ;; client for the Gitlab API.  See https://gitlab.com/tarsius/glab.
 
 ;; If you don't like this, then you might instead like `gh.el'; a big
 ;; client for the Github API.  See https://github.com/sigma/gh.el.
-
-;; If you would like to use `ghub.el', but also want dedicated
-;; functions for each API endpoint, then you can create those using
-;; `apiwrap.el'.  See https://github.com/vermiculus/apiwrap.el.
 
 ;;; Code:
 

--- a/ghub.el
+++ b/ghub.el
@@ -119,7 +119,7 @@
   (ghub--request "DELETE" resource params data noerror))
 
 (define-error 'ghub-error "Ghub Error")
-(define-error 'ghub-http-error "HTTP Error")
+(define-error 'ghub-http-error "HTTP Error" 'ghub-error)
 (define-error 'ghub-301 "Moved Permanently" 'ghub-http-error)
 (define-error 'ghub-400 "Bad Request" 'ghub-http-error)
 (define-error 'ghub-404 "Not Found" 'ghub-http-error)


### PR DESCRIPTION
This is based on, and replaces, #8.

Where the latter made some related changes in the same commit that added support for basic auth, this pr does those preparations in separate commits, which explain why those changes are made. Another difference is that this does not change the fall back behavior when a token request fails to use basic auth instead of an unauthorized request, instead it changes it to signal an error.

It also fixes a minor issue, removes the redundant `ghub-instance`, adds support for multiple tokens per instance (wip), and adds a command to generate a token (stub).

----

This is mostly untested, not least because while testing I ran into an issue that seems unrelated to these changes (also because I am traveling, and the setup I am forced to use, makes me rather unproductive). At least when unpaginating, then we might sometimes get `^M` as response, instead of a http response. Probably a bug in `url.el`, but I will have to investigate.

Also basic auth seems to keep a connection open and we might want to mimic that with token auth, but also make sure the user does not have to deal with the running process when quitting emacs.

Furthermore `url-basic-auth` also consults `~/.authinfo.gpg` and we will have to investigate what exactly it is locking for in there, but at least it does not seem to pick up our token, which wouldn't work since it isn't the password, and it doesn't write anything in there.