### PR TITLE
Fix instructions for authenticating via ghub.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ emacs ~/.authinfo.gpg
 
 ```
 # -*- epa-file-encrypt-to: ("A.U.Thor@example.com") -*-
-machine api.github.com login <login> password <token>
+machine github.com login <login> password <token>
 ```
 
 Usage examples

--- a/ghub.el
+++ b/ghub.el
@@ -36,7 +36,7 @@
 ;;   $ git config github.user <username>
 ;;   $ emacs ~/.authinfo.gpg
 ;;   # -*- epa-file-encrypt-to: ("A.U.Thor@example.com") -*-
-;;   machine api.github.com login <login> password <token>
+;;   machine github.com login <login> password <token>
 
 ;; Usage examples
 ;; --------------


### PR DESCRIPTION
Since `ghub-instance` is passed to `auth-source-search` [here](https://github.com/tarsius/ghub/blob/2948899e14d2704102cb9c2bfc57840fc62f43fd/ghub.el#L191), and `ghub-instance` is [defined to github.com](https://github.com/tarsius/ghub/blob/2948899e14d2704102cb9c2bfc57840fc62f43fd/ghub.el#L98), the recommended 'machine' should also be github.com, instead of api.github.com. Once making this change, everything is authenticated properly!

Let me know if this seems wrong, or if there's anything wrong with this PR.
