### PR TITLE
Avoid unnecessary loading of subr-x at runtime

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -101,9 +101,10 @@
 
 (require 'auth-source)
 (require 'json)
-(require 'subr-x)
 (require 'url)
 (require 'url-auth)
+
+(eval-when-compile (require 'subr-x))
 
 (defvar url-http-end-of-headers)
 (defvar url-http-response-status)


### PR DESCRIPTION
The only function this package exports is `read-multiple-choice`, the rest being macros.