### PR TITLE
Signal an error if username cannot be found

### DIFF
--- a/ghub.el
+++ b/ghub.el
@@ -257,18 +257,17 @@ For Github enterprise instances, get the value of `HOST.user',
 where HOST is the host part of the `URI', with dots replaced with
 underscores.  E.g. `gh_example_com.user' for gh.example.com/api."
   (or ghub-username
-      (let ((user
-             (shell-command-to-string
-              (format
-               "git config %s.user"
-               (if (string= ghub-base-url "https://api.github.com")
-                   "github"
-                 (subst-char-in-string
-                  ?. ?_ (replace-regexp-in-string
-                         "\\`https?://\\([^/]+\\)" "\\1" ghub-base-url)))))))
-        (if (string-empty-p user)
-            (signal 'ghub-auth-error '("Username not found"))
-          (substring user 0 -1)))))
+      (condition-case nil
+          (car (process-lines
+                "git" "config"
+                (format
+                 "%s.user"
+                 (if (string= ghub-base-url "https://api.github.com")
+                     "github"
+                   (subst-char-in-string
+                    ?. ?_ (replace-regexp-in-string
+                           "\\`https?://\\([^/]+\\)" "\\1" ghub-base-url))))))
+        (error (signal 'ghub-auth-error '("Username not found"))))))
 
 (defun ghub-wait (resource)
   "Busy-wait until RESOURCE becomes available."


### PR DESCRIPTION
* Do not call `substring` on an empty, non-configured username; signal `ghub-auth-error` instead.
* Call git process directly, not via shell, to avoid shell escaping issues.